### PR TITLE
bootleg pr: high vr role ping

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -22,6 +22,8 @@ export interface Config {
     roomPingChannel: string,
     roomTypeNameMap: Dictionary<string>,
     roomPingRoles: Dictionary<string>,
+    highVrPingRole: string,
+    highVrThreshold: number,
     modRestrictPerm: string
     friendbot: string
     packOwners: Dictionary<string[]>
@@ -92,6 +94,8 @@ export function initConfig(path: string) {
                 roomPingChannel: "Channel id to send room openings to.",
                 roomTypeNameMap: {},
                 roomPingRoles: {},
+                highVrPingRole: "Role ID for the high vr ping role",
+                highVrThreshold: 50000, // it's the threshold where if a room is above it the highVrPingRole will be pinged.
                 modRestrictPerm: "Permission used to restrict mod commands. See PermissionFlagsBits",
                 friendbot: "FC used to link discord accounts to WFC profiles.",
                 packOwners: {},

--- a/config.ts
+++ b/config.ts
@@ -22,8 +22,9 @@ export interface Config {
     roomPingChannel: string,
     roomTypeNameMap: Dictionary<string>,
     roomPingRoles: Dictionary<string>,
-    highVrPingRole: string,
-    highVrThreshold: number,
+    highVRPingRole: string,
+    highVRMinVR: number,
+    highVRMinPlayers: number,
     modRestrictPerm: string
     friendbot: string
     packOwners: Dictionary<string[]>
@@ -94,8 +95,9 @@ export function initConfig(path: string) {
                 roomPingChannel: "Channel id to send room openings to.",
                 roomTypeNameMap: {},
                 roomPingRoles: {},
-                highVrPingRole: "Role ID for the high vr ping role",
-                highVrThreshold: 50000, // it's the threshold where if a room is above it the highVrPingRole will be pinged.
+                highVRPingRole: "Role ID for the high vr ping role",
+                highVRMinVR: 40000, // it's the threshold where if a room is above it the highVrPingRole will be pinged.
+                highVRMinPlayers: 6,
                 modRestrictPerm: "Permission used to restrict mod commands. See PermissionFlagsBits",
                 friendbot: "FC used to link discord accounts to WFC profiles.",
                 packOwners: {},

--- a/services/groups.ts
+++ b/services/groups.ts
@@ -33,6 +33,7 @@ export interface Group {
     host: string,
     rk: string,
     players: Dictionary<Player>,
+    averageVR?: number,  // fetched from the api
 }
 
 interface Groups {
@@ -47,14 +48,22 @@ export function getGroups() {
     return groups;
 }
 
-const fetchGroupsUrl = `http://${config.wfcServer}:${config.wfcPort}/api/groups`;
+// const fetchGroupsUrl = `http://${config.wfcServer}:${config.wfcPort}/api/groups`;  // change this back
+const fetchGroupsUrl = `https://status.rwfc.net/groups`;  // todo change this back
 
 async function fetchGroups() {
-    const groupsJson = (await utils.queryJson(fetchGroupsUrl)) ?? utils.throwInline("Empty or no json response from groups api.");
-    groups = { timestamp: Date.now(), rooms: groupsJson };
+    // todo change this back too since the api used in the code is different, but i dont have access to it
+    const apiResponse = await utils.queryJson(fetchGroupsUrl);
+    // const groupsJson = (await utils.queryJson(fetchGroupsUrl)) ?? utils.throwInline("Empty or no json response from groups api.");
+    if (!apiResponse || !apiResponse.rooms) {
+        if (config.logServices) console.error("invalid api response")
+        return;
+    }
+    // groups = { timestamp: Date.now(), rooms: groupsJson };
+    groups = { timestamp: apiResponse.timestamp || Date.now(), rooms: apiResponse.rooms };
 
     if (config.logServices)
-        console.log(`Successfully fetched groups! Time is ${new Date(Date.now())}`);
+        console.log(`Successfully fetched groups! Time is ${new Date(Date.now())}.\n fetched ${groups.rooms.length} rooms`);
 
     await sendPings();
     return;
@@ -75,8 +84,16 @@ async function sendPings() {
         }
 
         const groupName = config.roomTypeNameMap[group.rk] ?? group.rk;
-        // Guaranteed to exist, otherwise the message would not exist
-        const groupPing = config.roomPingRoles[group.rk];
+        const playerCount = Object.keys(group.players).length;
+        const isHighVR = group.averageVR && group.averageVR >= config.highVrThreshold;
+        const isSweatyRoom = isHighVR && playerCount > 5;
+
+        let groupPing = config.roomPingRoles[group.rk];
+        if (isSweatyRoom && config.highVrPingRole) {
+            groupPing = config.highVrPingRole;
+        }
+
+        const roleMention = groupPing ? `<@&${groupPing}>,` : `Room Update:`;
 
         // Delete the room
         if (!groupsContains(groups!.rooms, group)) {
@@ -98,9 +115,15 @@ async function sendPings() {
         }
 
         // Otherwise, update the room.
-        const playerCount = Object.keys(group.players).length;
+        const highVRDisplay = isSweatyRoom ? ` and **${group.averageVR}** Avg VR` : "";
+        let roomMessageUpdate = ""
+        if (roleMention == "Room Update:") {
+            roomMessageUpdate = `${roleMention} ${aOrAn(groupName)} ${groupName} room (${group.id}) is open, but is not considered high VR anymore.`
+        } else {
+            roomMessageUpdate = `${roleMention} ${aOrAn(groupName)} ${groupName} room (${group.id}) is open with ${playerCount} ${utils.plural(playerCount, "player")}${highVRDisplay}!`
+        }
         const message = await roomMessage.edit(
-            `<@&${groupPing}>, ${aOrAn(groupName)} ${groupName} room (${group.id}) is open with ${playerCount} ${utils.plural(playerCount, "player")}!`
+            roomMessageUpdate
         );
 
         if (!message)
@@ -127,16 +150,36 @@ async function sendPings() {
         }
 
         const groupName = config.roomTypeNameMap[group.rk] ?? group.rk;
-        const groupPing = config.roomPingRoles[group.rk];
+        let groupPing = config.roomPingRoles[group.rk];
 
-        if (!groupPing) {
+        const high_vr_threshold = config.highVrThreshold;
+        const isHighVR = group.averageVR && group.averageVR >= high_vr_threshold;
+        const playerCount = Object.keys(group.players).length;
+        let isSweatyRoom = false;
+        if (isHighVR && playerCount > 10) {
+            isSweatyRoom = true;
+        } else if (isHighVR && playerCount < 11) {
+            console.log(`Skipping high vr room ${group.id} with low player count ${playerCount}`);
+        }
+
+        if (isSweatyRoom && config.highVrPingRole) {
+            // set groupPing to high vr role regardless of mode, but only if the room is above threshhold and has enough players.
+            groupPing = config.highVrPingRole;
+        }
+
+
+        if (!groupPing) {  // room is not in the pingable roles and is not sweaty (high vr & 6+ players)
             if (config.logServices)
                 console.error(`No role has been configured to alert for rooms of type ${group.rk}, for room ${group.id}`);
 
             continue;
         }
 
-        const content = `<@&${groupPing}>, ${aOrAn(groupName)} ${groupName} room (${group.id}) has opened!`;
+        let content = `<@&${groupPing}>, ${aOrAn(groupName)} ${groupName} room (${group.id}) has opened!`;
+
+        if (isSweatyRoom) {
+            content = `<@&${groupPing}>, ${aOrAn(groupName)} ${groupName} room (${group.id}) with ${group.averageVR} VR and ${playerCount} players has opened!`;
+        }
 
         if (config.logServices)
             console.log(`Sending message ${content}`);

--- a/services/groups.ts
+++ b/services/groups.ts
@@ -48,22 +48,14 @@ export function getGroups() {
     return groups;
 }
 
-// const fetchGroupsUrl = `http://${config.wfcServer}:${config.wfcPort}/api/groups`;  // change this back
-const fetchGroupsUrl = `https://status.rwfc.net/groups`;  // todo change this back
+const fetchGroupsUrl = `http://${config.wfcServer}:${config.wfcPort}/api/groups`;
 
 async function fetchGroups() {
-    // todo change this back too since the api used in the code is different, but i dont have access to it
-    const apiResponse = await utils.queryJson(fetchGroupsUrl);
-    // const groupsJson = (await utils.queryJson(fetchGroupsUrl)) ?? utils.throwInline("Empty or no json response from groups api.");
-    if (!apiResponse || !apiResponse.rooms) {
-        if (config.logServices) console.error("invalid api response")
-        return;
-    }
-    // groups = { timestamp: Date.now(), rooms: groupsJson };
-    groups = { timestamp: apiResponse.timestamp || Date.now(), rooms: apiResponse.rooms };
+    const groupsJson = (await utils.queryJson(fetchGroupsUrl)) ?? utils.throwInline("Empty or no json response from groups api.");
+    groups = { timestamp: Date.now(), rooms: groupsJson };
 
     if (config.logServices)
-        console.log(`Successfully fetched groups! Time is ${new Date(Date.now())}.\n fetched ${groups.rooms.length} rooms`);
+        console.log(`Successfully fetched groups! Time is ${new Date(Date.now())}. fetched ${groups.rooms.length} rooms`);
 
     await sendPings();
     return;

--- a/services/groups.ts
+++ b/services/groups.ts
@@ -33,7 +33,7 @@ export interface Group {
     host: string,
     rk: string,
     players: Dictionary<Player>,
-    averageVR?: number,  // fetched from the api
+    averageVR: number,
 }
 
 interface Groups {
@@ -57,6 +57,15 @@ async function fetchGroups() {
     if (config.logServices)
         console.log(`Successfully fetched groups! Time is ${new Date(Date.now())}. fetched ${groups.rooms.length} rooms`);
 
+    for (const room of groups.rooms) {
+        let totalVR = 0;
+
+        for (const player of Object.values(room.players))
+            totalVR += Number(player.ev);
+
+        room.averageVR = Math.floor(totalVR / Object.keys(room.players).length);
+    }
+
     await sendPings();
     return;
 }
@@ -77,15 +86,14 @@ async function sendPings() {
 
         const groupName = config.roomTypeNameMap[group.rk] ?? group.rk;
         const playerCount = Object.keys(group.players).length;
-        const isHighVR = group.averageVR && group.averageVR >= config.highVrThreshold;
+        const isHighVR = group.averageVR && group.averageVR >= config.highVRMinVR;
         const isSweatyRoom = isHighVR && playerCount > 5;
 
         let groupPing = config.roomPingRoles[group.rk];
-        if (isSweatyRoom && config.highVrPingRole) {
-            groupPing = config.highVrPingRole;
-        }
+        if (isSweatyRoom && config.highVRPingRole)
+            groupPing = config.highVRPingRole;
 
-        const roleMention = groupPing ? `<@&${groupPing}>,` : `Room Update:`;
+        const roleMention = groupPing ? `<@&${groupPing}>,` : "Room Update:";
 
         // Delete the room
         if (!groupsContains(groups!.rooms, group)) {
@@ -108,12 +116,12 @@ async function sendPings() {
 
         // Otherwise, update the room.
         const highVRDisplay = isSweatyRoom ? ` and **${group.averageVR}** Avg VR` : "";
-        let roomMessageUpdate = ""
-        if (roleMention == "Room Update:") {
-            roomMessageUpdate = `${roleMention} ${aOrAn(groupName)} ${groupName} room (${group.id}) is open, but is not considered high VR anymore.`
-        } else {
-            roomMessageUpdate = `${roleMention} ${aOrAn(groupName)} ${groupName} room (${group.id}) is open with ${playerCount} ${utils.plural(playerCount, "player")}${highVRDisplay}!`
-        }
+        let roomMessageUpdate = "";
+        if (roleMention == "Room Update:")
+            roomMessageUpdate = `${roleMention} ${aOrAn(groupName)} ${groupName} room (${group.id}) is open, but is not considered high VR anymore.`;
+        else
+            roomMessageUpdate = `${roleMention} ${aOrAn(groupName)} ${groupName} room (${group.id}) is open with ${playerCount} ${utils.plural(playerCount, "player")}${highVRDisplay}!`;
+
         const message = await roomMessage.edit(
             roomMessageUpdate
         );
@@ -144,21 +152,24 @@ async function sendPings() {
         const groupName = config.roomTypeNameMap[group.rk] ?? group.rk;
         let groupPing = config.roomPingRoles[group.rk];
 
-        const high_vr_threshold = config.highVrThreshold;
-        const isHighVR = group.averageVR && group.averageVR >= high_vr_threshold;
+        const isHighVR = group.averageVR >= config.highVRMinVR;
         const playerCount = Object.keys(group.players).length;
-        let isSweatyRoom = false;
-        if (isHighVR && playerCount > 10) {
-            isSweatyRoom = true;
-        } else if (isHighVR && playerCount < 11) {
+        const isSweatyRoom = isHighVR && playerCount >= config.highVRMinPlayers;
+
+        if (isHighVR && !isSweatyRoom)
             console.log(`Skipping high vr room ${group.id} with low player count ${playerCount}`);
-        }
 
-        if (isSweatyRoom && config.highVrPingRole) {
+        if (isSweatyRoom) {
             // set groupPing to high vr role regardless of mode, but only if the room is above threshhold and has enough players.
-            groupPing = config.highVrPingRole;
-        }
+            groupPing = config.highVRPingRole;
 
+            if (!groupPing) {
+                if (config.logServices)
+                    console.error(`No role has been configured to alert for high Vr rooms, for room ${group.id}`);
+
+                continue;
+            }
+        }
 
         if (!groupPing) {  // room is not in the pingable roles and is not sweaty (high vr & 6+ players)
             if (config.logServices)
@@ -169,9 +180,8 @@ async function sendPings() {
 
         let content = `<@&${groupPing}>, ${aOrAn(groupName)} ${groupName} room (${group.id}) has opened!`;
 
-        if (isSweatyRoom) {
+        if (isSweatyRoom)
             content = `<@&${groupPing}>, ${aOrAn(groupName)} ${groupName} room (${group.id}) with ${group.averageVR} VR and ${playerCount} players has opened!`;
-        }
 
         if (config.logServices)
             console.log(`Sending message ${content}`);


### PR DESCRIPTION
implemented a simple version of the high vr room ping, worked on my test server:
<img width="750" height="370" alt="{0BE1E245-30AF-4429-8E14-7E2858B9458E}" src="https://github.com/user-attachments/assets/ed65108c-6c9d-4a56-a5fc-170602db4db9" />

changes:
- added 2 new lines in the config.json:
```
"highVrPingRole": "1472954796641226938",
"highVrThreshold": 50000,
```
- changed config.ts to accept them
- added a new ping and the functionality to
1. ping about high vr rooms when they're opened and have 6 or more players (even 150cc rooms with no role)
2. update their player and vr count every minute
3. update the room to remove the ping if it isn't high vr anymore (still exists but goes below the threshold)
4. ping again if the room goes above the threshold again

todo:
- ping two roles at once if the high vr room is a special mode (ct, 200cc etc.)
- test more thoroughly with unit tests (idk if it works if the room goes from 6 players to 5 and then back up to 6 since i couldn't test)

not expecting this to be merged, just didnt want my effort going to waste