### PR TITLE
Refine no-results handling in flag_jumps

### DIFF
--- a/commands/flag_jumps.ts
+++ b/commands/flag_jumps.ts
@@ -46,7 +46,7 @@ export default {
             if (leaderboardResponse.ok) {
                 const res = await leaderboardResponse.json();
 
-                if (res.count === 0) {
+                if (res.count === 0 && !res.player.flagReason && !res.player.unflagReason) {
                     await interaction.editReply({
                         content: `No suspicious VR jumps found for player ${res.player.name} (${fc})`
                     });
@@ -89,8 +89,11 @@ export default {
                     });
                 }
 
-                if (res.count > 25)
+                if (res.count === 0) {
+                    embed.setFooter({ text: "No suspicious jumps detected" });
+                } else if (res.count > 25) {
                     embed.setFooter({ text: `Showing 25 of ${res.count} suspicious jumps` });
+                }
 
                 await interaction.editReply({ embeds: [embed] });
             }

--- a/commands/flag_jumps.ts
+++ b/commands/flag_jumps.ts
@@ -89,11 +89,11 @@ export default {
                     });
                 }
 
-                if (res.count === 0) {
+                if (res.count === 0)
                     embed.setFooter({ text: "No suspicious jumps detected" });
-                } else if (res.count > 25) {
+                else if (res.count > 25)
                     embed.setFooter({ text: `Showing 25 of ${res.count} suspicious jumps` });
-                }
+
 
                 await interaction.editReply({ embeds: [embed] });
             }


### PR DESCRIPTION
Only send the "No suspicious VR jumps found" reply when res.count is 0 and the player has no flagReason or unflagReason, preventing the no-results message from hiding existing flag/unflag details